### PR TITLE
fix(wounds): set per-level base penalties on PC actors (#32)

### DIFF
--- a/module/documents/actor/preparation/pc-preparation.js
+++ b/module/documents/actor/preparation/pc-preparation.js
@@ -160,6 +160,11 @@ export function preparePcData(actor, sys, finalizeWoundPenaltiesFn, calculateIns
       } else {
         lvl.value = earth * mult + prev + add;
       }
+      // Reset base per-level penalty (issue #32): without this, every PC wound level
+      // had penalty=0, so calculateWoundPenalties would compute the same penaltyEff
+      // for every row from the modifier alone — including Healthy, which should
+      // always be 0 regardless of modifier.
+      lvl.penalty = DEFAULT_WOUND_PENALTIES[key] ?? 0;
       prev = lvl.value;
     }
   } catch (err) {


### PR DESCRIPTION
## Summary

Fixes #32 — wound penalty display bug where every wound level row showed the same value (derived purely from the `woundsPenaltyMod` modifier), including Healthy which should always show `0`.

## Root cause

In \`module/documents/actor/preparation/pc-preparation.js\`, when PC wound levels were built from Earth Ring formulas, the loop set each level's threshold (\`lvl.value\`) but **never set the per-level base penalty** (\`lvl.penalty\`). New wound level objects were created with the literal default \`{ value: 0, penalty: 0, current: false }\` and that \`penalty: 0\` was never overwritten with \`DEFAULT_WOUND_PENALTIES[key]\`.

So every PC wound level had \`penalty = 0\` regardless of which level it was, and \`calculateWoundPenalties\` then computed:

\`\`\`
penaltyEff = max(0, lvl.penalty + woundsPenaltyMod)
           = max(0, 0 + woundsPenaltyMod)
\`\`\`

Every row showed the same value:
- With \`woundsPenaltyMod = +5\`: every row including Healthy shows \`5\` ❌
- With \`woundsPenaltyMod = -3\`: every row shows \`0\` (the negative is clamped)

## Fix

One-line addition in the wound-level setup loop:

\`\`\`js
lvl.penalty = DEFAULT_WOUND_PENALTIES[key] ?? 0;
\`\`\`

Now each level gets its correct base penalty (\`healthy: 0, nicked: 3, grazed: 5, hurt: 10, injured: 15, crippled: 20, down: 40, out: 40\`) on every prep cycle, and \`calculateWoundPenalties\` produces the right per-level effective penalties.

## Testing

- \`npm run lint:js\` — clean
- \`npx vitest run tests/unit/documents/wound-calculations.test.js\` — 37/37 passing (existing tests for \`calculateWoundPenalties\` confirm the function is correct given correct input data; the bug was in input data, not the calc)
- \`npx prettier --check\` — clean
- Pre-commit hooks (lint-staged: eslint --fix, prettier --write) — green

## Note to maintainer

You commented on #32 \"Found the issue and will be in the next release\" — I saw that comment. If you have a different fix in flight, feel free to close this PR and use yours. I went with the smallest possible change at the source of the bug. No regression test was added because exercising \`preparePcData\` end-to-end requires mocking many dependencies (\`prepareTraitsAndRings\`, \`applyStanceAutomation\`, \`applyConditionEffects\`, etc.) — happy to add one if you'd prefer.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)