### PR TITLE
fix(skills): bridge skill-item bonuses to weapon attacks (#34)

### DIFF
--- a/module/documents/actor/calculations/item-enrichment.js
+++ b/module/documents/actor/calculations/item-enrichment.js
@@ -50,7 +50,15 @@ export function enrichActorItems(actor) {
   }
 
   try {
-    // Process each item based on its type
+    // First pass: aggregate skill-item bonuses into actor.system.bonuses.skill so
+    // downstream readers (enrichSkillFormulas, resolveWeaponSkillTrait,
+    // applySkillAndTraitBonuses) all see Active-Effect contributions on skill items.
+    // See issue #34: AEs targeting `skill.system.rollBonus` previously had no effect
+    // on weapon attack rolls because nothing bridged item-level bonuses into the
+    // actor-level bonus map that the dice services read.
+    aggregateSkillItemBonuses(actor);
+
+    // Second pass: enrich individual items with derived formulas
     for (const item of actor.items) {
       if (!item?.type) {
         continue;
@@ -77,6 +85,53 @@ export function enrichActorItems(actor) {
       actorName: actor?.name
     });
     // Items remain unenriched - formulas won't display but won't break functionality
+  }
+}
+
+/**
+ * Aggregate skill-item bonus fields into actor.system.bonuses.skill.
+ *
+ * @param {Actor} actor - The actor whose skill items should be aggregated
+ *
+ * @description
+ * Walks every skill item on the actor and adds its `system.rollBonus`,
+ * `system.keepBonus`, and `system.totalBonus` values into the corresponding
+ * `actor.system.bonuses.skill[skillNameLowercase]` entry. This bridges the
+ * item-level bonus storage (where Active Effects on skill items deposit values
+ * per ACTIVE_EFFECTS.md docs) into the actor-level bonus map that
+ * `applySkillAndTraitBonuses` reads at roll time.
+ *
+ * Idempotency: Foundry calls `prepareDerivedData` against a freshly-rehydrated
+ * `actor.system` each cycle, so this aggregation always runs against the base
+ * (post-Active-Effect) values — there is no accumulation across prep cycles.
+ *
+ * Multiple skill items with the same name (case-insensitive) accumulate.
+ *
+ * @private
+ */
+function aggregateSkillItemBonuses(actor) {
+  if (!actor?.system) {
+    return;
+  }
+  actor.system.bonuses = actor.system.bonuses || {};
+  actor.system.bonuses.skill = actor.system.bonuses.skill || {};
+
+  for (const item of actor.items) {
+    if (!item || item.type !== "skill") {
+      continue;
+    }
+    const key = String(item.name ?? "")
+      .toLowerCase()
+      .trim();
+    if (!key) {
+      continue;
+    }
+    const existing = actor.system.bonuses.skill[key] || {};
+    actor.system.bonuses.skill[key] = {
+      roll: toInt(existing.roll) + toInt(item.system?.rollBonus),
+      keep: toInt(existing.keep) + toInt(item.system?.keepBonus),
+      total: toInt(existing.total) + toInt(item.system?.totalBonus)
+    };
   }
 }
 

--- a/module/utils/mechanics.js
+++ b/module/utils/mechanics.js
@@ -335,13 +335,23 @@ export function resolveWeaponSkillTrait(actor, weapon) {
     const traitValue = getEffectiveTrait(actor, skillTrait);
     const skillName = toString(skill.name, "Unknown Skill");
 
+    // Pick up skill bonuses aggregated by item-enrichment.aggregateSkillItemBonuses
+    // (issue #34): Active Effects on a skill item deposit into skill.system.rollBonus,
+    // which item-enrichment then bridges to actor.system.bonuses.skill[name]. Reading
+    // those bonuses here makes the displayed weapon attack formula match what
+    // applySkillAndTraitBonuses will compute at roll time.
+    const skillKey = skillName.toLowerCase();
+    const skillBonusMap = actor.system?.bonuses?.skill?.[skillKey] || {};
+    const skillBonusRoll = toInt(skillBonusMap.roll);
+    const skillBonusKeep = toInt(skillBonusMap.keep);
+
     // Rank 0 counts as unskilled (roll and keep both = trait)
     if (skillRank === 0) {
       return {
         skillRank: 0,
         traitValue,
-        rollBonus: traitValue,
-        keepBonus: traitValue,
+        rollBonus: traitValue + skillBonusRoll,
+        keepBonus: traitValue + skillBonusKeep,
         description: `${skillName} (${skillRank}) + ${skillTrait.toUpperCase()} (${traitValue}) [Unskilled]`
       };
     }
@@ -350,8 +360,8 @@ export function resolveWeaponSkillTrait(actor, weapon) {
     return {
       skillRank,
       traitValue,
-      rollBonus: skillRank + traitValue,
-      keepBonus: traitValue,
+      rollBonus: skillRank + traitValue + skillBonusRoll,
+      keepBonus: traitValue + skillBonusKeep,
       description: `${skillName} (${skillRank}) + ${skillTrait.toUpperCase()} (${traitValue})`
     };
   } else {

--- a/tests/unit/utils/mechanics.test.js
+++ b/tests/unit/utils/mechanics.test.js
@@ -873,6 +873,101 @@ describe("resolveWeaponSkillTrait", () => {
     });
   });
 
+  // Regression tests for issue #34: skill bonuses (e.g. from Active Effects on
+  // the skill item, aggregated by item-enrichment.aggregateSkillItemBonuses)
+  // should flow into the displayed weapon attack formula.
+  describe("skill bonuses propagate to weapon attack (issue #34)", () => {
+    const buildActorWithSkillBonus = (kenjutsuRank, bonusRoll, bonusKeep) => ({
+      system: {
+        traits: { agi: 3 },
+        bonuses: {
+          skill: {
+            kenjutsu: { roll: bonusRoll, keep: bonusKeep, total: 0 }
+          }
+        }
+      },
+      items: {
+        find: vi.fn(cb => {
+          const skill = {
+            type: "skill",
+            name: "Kenjutsu",
+            system: { rank: kenjutsuRank, trait: "agi" }
+          };
+          return cb(skill) ? skill : undefined;
+        })
+      }
+    });
+
+    it("should add skill rollBonus to skilled attack rollBonus", () => {
+      // Skilled: rank 4 + agi 3 = 7, plus +2k0 from skill bonus → 9k3
+      const actor = buildActorWithSkillBonus(4, 2, 0);
+      const weapon = { system: { associatedSkill: "Kenjutsu", fallbackTrait: "agi" } };
+
+      const result = resolveWeaponSkillTrait(actor, weapon);
+
+      expect(result.rollBonus).toBe(9);
+      expect(result.keepBonus).toBe(3);
+    });
+
+    it("should add skill keepBonus to skilled attack keepBonus", () => {
+      // Skilled: rank 4 + agi 3 = 7 roll, agi 3 keep, plus +0k1 → 7k4
+      const actor = buildActorWithSkillBonus(4, 0, 1);
+      const weapon = { system: { associatedSkill: "Kenjutsu", fallbackTrait: "agi" } };
+
+      const result = resolveWeaponSkillTrait(actor, weapon);
+
+      expect(result.rollBonus).toBe(7);
+      expect(result.keepBonus).toBe(4);
+    });
+
+    it("should support negative skill bonuses (penalties)", () => {
+      // Penalty case from the issue: skilled rank 4 + agi 3 = 7k3, with -1k1 → 6k2
+      const actor = buildActorWithSkillBonus(4, -1, -1);
+      const weapon = { system: { associatedSkill: "Kenjutsu", fallbackTrait: "agi" } };
+
+      const result = resolveWeaponSkillTrait(actor, weapon);
+
+      expect(result.rollBonus).toBe(6);
+      expect(result.keepBonus).toBe(2);
+    });
+
+    it("should add skill bonuses to unskilled attack rollBonus too", () => {
+      // Unskilled (rank 0): trait 3 keep 3, with +1k0 → 4k3
+      const actor = buildActorWithSkillBonus(0, 1, 0);
+      const weapon = { system: { associatedSkill: "Kenjutsu", fallbackTrait: "agi" } };
+
+      const result = resolveWeaponSkillTrait(actor, weapon);
+
+      expect(result.skillRank).toBe(0);
+      expect(result.rollBonus).toBe(4);
+      expect(result.keepBonus).toBe(3);
+      expect(result.description).toContain("[Unskilled]");
+    });
+
+    it("should be safe when actor has no bonuses.skill map", () => {
+      // No bonus map at all — should behave exactly like the pre-fix path
+      const actor = {
+        system: { traits: { agi: 3 } },
+        items: {
+          find: vi.fn(cb => {
+            const skill = {
+              type: "skill",
+              name: "Kenjutsu",
+              system: { rank: 4, trait: "agi" }
+            };
+            return cb(skill) ? skill : undefined;
+          })
+        }
+      };
+      const weapon = { system: { associatedSkill: "Kenjutsu", fallbackTrait: "agi" } };
+
+      const result = resolveWeaponSkillTrait(actor, weapon);
+
+      expect(result.rollBonus).toBe(7);
+      expect(result.keepBonus).toBe(3);
+    });
+  });
+
   describe("edge cases", () => {
     it("should handle null weapon", () => {
       const actor = {};


### PR DESCRIPTION
## Summary

Fixes #34 — Active Effects targeting a skill item's `system.rollBonus` / `system.keepBonus` (the approach documented in `ACTIVE_EFFECTS.md` line 182) had no effect on weapon attack rolls. The user reported \"I add a penalty of -1k1 to Kenjutsu, then add a weapon using that skill and roll an attack, it doesn't carry over that penalty\" — and noted Active Effects also failed to work as a workaround.

## Root cause

There were two completely disconnected paths for skill bonuses:

| Path | Where it lives | Who reads it |
|------|---------------|--------------|
| **Item-level**: `skill.system.rollBonus` / `keepBonus` | On the embedded skill item | (nothing) |
| **Actor-level**: `actor.system.bonuses.skill[name].roll` / `keep` | On the actor | `enrichSkillFormulas`, `applySkillAndTraitBonuses` |

`ACTIVE_EFFECTS.md` documents Active Effects targeting the item-level path (line 182):

> **Example:** School grants +1k0 to Kenjutsu
> - Target: Embedded Kenjutsu skill item
> - Attribute Key: \`system.rollBonus\`
> - Change Mode: Add
> - Effect Value: \`1\`

…but **nothing aggregated those item-level bonuses into the actor-level map**, so the dice services couldn't see them. The runtime path:

1. Click attack on weapon
2. \`weaponAttackRoll\` → \`resolveWeaponSkillTrait\` (computes \`rollBonus = skillRank + traitValue\`, ignores item bonuses)
3. \`weaponAttackRoll\` → \`SkillRoll\` → \`applySkillAndTraitBonuses(actor, skillName, …)\` → reads \`actor.system.bonuses.skill[skillName]\` (which was empty for AE-driven skill bonuses)
4. Roll fires with no skill-bonus contribution

## Fix

**Two changes, one root cause:**

1. **`module/documents/actor/calculations/item-enrichment.js`** — Add a new `aggregateSkillItemBonuses(actor)` function called as a first pass in `enrichActorItems`. It walks every skill item on the actor and adds its `rollBonus` / `keepBonus` / `totalBonus` into `actor.system.bonuses.skill[name.toLowerCase()]`. This bridges the documented Active-Effect storage location to the path the dice services already read.

2. **`module/utils/mechanics.js`** — Update `resolveWeaponSkillTrait` to also read those aggregated bonuses, so the *displayed* weapon attack formula matches what `applySkillAndTraitBonuses` will compute at roll time.

**Idempotency**: Foundry's \`prepareDerivedData\` is called against a freshly rehydrated \`actor.system\` each cycle, so the aggregation always runs against the same base (post-Active-Effect) values. No double-counting risk.

## What works now

- AE on Kenjutsu skill item with \`system.rollBonus = -1\`, \`system.keepBonus = -1\` → weapon using Kenjutsu shows reduced attack formula and rolls with the penalty applied. (The exact issue scenario.)
- Skill bonuses also flow through to non-weapon skill rolls (since both call \`applySkillAndTraitBonuses\`).
- Multiple AE sources stack additively (per L5R4 rules).
- Penalties (negative bonuses) work correctly.
- Unskilled rolls (rank 0) also get the bonuses.

## Tests

Added 5 regression tests in \`tests/unit/utils/mechanics.test.js\` under \`describe(\"skill bonuses propagate to weapon attack (issue #34)\")\`:

- \`should add skill rollBonus to skilled attack rollBonus\` (+2k0)
- \`should add skill keepBonus to skilled attack keepBonus\` (+0k1)
- \`should support negative skill bonuses (penalties)\` (the exact -1k1 case from the issue)
- \`should add skill bonuses to unskilled attack rollBonus too\`
- \`should be safe when actor has no bonuses.skill map\` (no-regression for the pre-fix path)

Test results:
- \`npx vitest run tests/unit/utils/mechanics.test.js\` — **80/80 passing** (was 75)
- \`npx vitest run\` (full suite) — **1015/1015 passing**
- \`npm run lint:js\` — clean
- Pre-commit hooks (lint-staged: eslint --fix + prettier --write) — green

## Notes for maintainer

- I did **not** add a UI for editing weapon-level attack mods (one of the workarounds the user mentioned wanting). Adding fields like \`weapon.system.attackRollMod\` / \`attackKeepMod\` would be a schema change with template/sheet/migration impact, and it's a separable feature. The Active-Effect-on-skill path should now satisfy most use cases. Happy to do the weapon-level mod feature as a follow-up PR if you want.
- The fix is additive in actor.system.bonuses.skill — if anything else (a future plugin, a custom advantage) writes there directly, those bonuses still apply and stack with skill-item bonuses.
- The hard rules from the operator's BOOT.md were honored: branched off main, no direct main push, no force, no \`--no-verify\`, no merge from me.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)